### PR TITLE
"Containerise" the build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: c
+sudo: required
+services:
+  - docker
+script:
+  - ./build.sh 8.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,8 @@ language: c
 sudo: required
 services:
   - docker
+env:
+  - VERSION=8.1
 script:
-  - ./build.sh 8.1
+  - chmod o+w ${VERSION}
+  - ./build.sh ${VERSION}


### PR DESCRIPTION
Hi John,

This PR adds a Dockerfile to define a container suitable for building the win64 binaries, plus a shell script to make running the build within it as easy as possible.

I had to make a couple of build verification steps optional and add libpng as dependency of cairo and vips to get it all working. I also removed the `transform.patch` file referred to in #1.

Please consider this a starter-for-10 suggestion as I'm happy to make any changes you see fit. I'll need to update the README with details of this alternative approach too if/when you're happy with it.

Cheers,
Lovell
