### PR TITLE
Groundwork to enable builds with named groups of dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ packages
 checkout
 inst
 .*.swp
+vips-dev*.zip

--- a/8.3/build.sh
+++ b/8.3/build.sh
@@ -30,6 +30,6 @@ fi
 
 # do the win64 build and package
 if [ -d $linux_install ]; then
-  jhbuild --file=jhbuildrc build --nodeps libvips && \
+  jhbuild --file=jhbuildrc build --nodeps libvips-$DEPS && \
     ./package-vipsdev.sh
 fi

--- a/8.3/package-vipsdev.sh
+++ b/8.3/package-vipsdev.sh
@@ -81,4 +81,4 @@ fi
 
 echo creating $vips_package-dev-w64-$vips_version.zip
 rm -f $vips_package-dev-w64-$vips_version.zip
-zip -r -qq $vips_package-dev-w64-$vips_version.zip $vips_package-dev-$vips_version
+zip -r -qq $vips_package-dev-w64-$DEPS-$vips_version.zip $vips_package-dev-$vips_version

--- a/8.3/vips.modules
+++ b/8.3/vips.modules
@@ -615,7 +615,7 @@
 
     -->
 
-  <autotools id="libvips" 
+  <autotools id="libvips-all"
     autogen-sh="configure"
     autogenargs="--enable-debug=yes --without-OpenEXR --without-matio --without-orc --disable-introspection "
     makeargs="CFLAGS=-O3 CXXFLAGS=-O3"

--- a/build.sh
+++ b/build.sh
@@ -1,12 +1,14 @@
 #!/bin/sh
 
 if [ $# -lt 1 ]; then
-  echo "Usage: $0 VERSION"
+  echo "Usage: $0 VERSION [DEPS]"
   echo "Build libvips for win64 using Docker"
   echo "VERSION is the name of a versioned subdirectory, e.g. 8.1"
+  echo "DEPS is the group of dependencies to build libvips with, defaults to 'all'"
   exit 1
 fi
 VERSION="$1"
+DEPS="${2:-all}"
 
 if ! type docker > /dev/null; then
   echo "Please install docker"
@@ -17,7 +19,7 @@ fi
 docker build -t libvips-build-win64 container
 
 # Run build scripts inside container, with versioned subdirectory mounted at /data
-docker run --rm -t -v $PWD/$VERSION:/data libvips-build-win64 sh -c "cp /data/* .; ./build.sh && cp vips-dev-w64-*.zip /data"
+docker run --rm -t -v $PWD/$VERSION:/data -e "DEPS=$DEPS" libvips-build-win64 sh -c "cp /data/* .; ./build.sh && cp vips-dev-w64-*.zip /data"
 
 # List result
 ls -al $PWD/$VERSION/*.zip


### PR DESCRIPTION
Hi John, this PR is for a possible approach to allow libvips to be built with different groups of dependencies, e.g. "scientific", "web", "minimal" etc., for 64-bit Windows.

I've named the existing dependencies "all", which remains the default behaviour. The name of the group is propagated into the container via the `DEPS` environment variable, forming the suffix of the jhbuild module ID.

My experience of jhbuild is minimal, so feedback very much welcome for better/cleaner ways to achieve this. Once we're happy with the approach, I'll submit another PR for a "web" group of dependencies.

Cheers,
Lovell
