### PR TITLE
Upgrade lcms2 dependency to v2.8

### DIFF
--- a/8.3/vips.modules
+++ b/8.3/vips.modules
@@ -326,8 +326,8 @@
     >
     <branch
       repo="sourceforge"
-      module="lcms/lcms2-2.7.tar.gz"
-      version="2.7"
+      module="lcms/lcms2-2.8.tar.gz"
+      version="2.8"
     />
     <dependencies>
       <dep package="libiconv"/>


### PR DESCRIPTION
v8.3.2 appears to be working on Windows - see https://ci.appveyor.com/project/lovell/sharp/build/job/716qe9c8uq3529b8 (uses latest master plus this patch)
