### PR TITLE
replace ftp.remotesensing.org/pub repository with download.osgeo.org

### DIFF
--- a/8.4/vips.modules
+++ b/8.4/vips.modules
@@ -66,7 +66,7 @@
   <repository 
     type="tarball"
     name="tiff"
-    href="ftp://ftp.remotesensing.org/pub/libtiff/"
+    href="http://download.osgeo.org/libtiff/"
   />
 
   <repository 


### PR DESCRIPTION
ftp://ftp.remotesensing.org/pub/libtiff/ repository is not accessible anymore
