### PR TITLE
Updates and dependency bumps for 8.5

### DIFF
--- a/8.5/build.sh
+++ b/8.5/build.sh
@@ -7,7 +7,7 @@
 # export this to vips.modules ... cmake needs it
 export BASEDIR=$basedir
 
-vips_site=http://www.vips.ecs.soton.ac.uk/supported/$vips_version
+vips_site=https://github.com/jcupitt/libvips/releases/download/v$vips_version.$vips_minor_version
 
 # basic setup ... must do this before the native build, since it'll wipe the
 # install area

--- a/8.5/vips.modules
+++ b/8.5/vips.modules
@@ -463,8 +463,8 @@
     >
     <branch
       repo="tiff"
-      module="tiff-4.0.6.tar.gz"
-      version="4.0.6"
+      module="tiff-4.0.7.tar.gz"
+      version="4.0.7"
       >
     </branch>
     <dependencies>
@@ -552,8 +552,8 @@
     >
     <branch
       repo="webp"
-      module="libwebp-0.5.1.tar.gz"
-      version="0.5.1"
+      module="libwebp-0.6.0.tar.gz"
+      version="0.6.0"
       >
     </branch>
     <dependencies>
@@ -582,10 +582,9 @@
   <autotools id="glib" autogenargs="--with-pcre=internal">
     <branch
       repo="gnome"
-      module="glib/2.49/glib-2.49.4.tar.xz"
-      version="2.49.4"
+      module="glib/2.52/glib-2.52.0.tar.xz"
+      version="2.52.0"
       >
-      <patch file="http://www.vips.ecs.soton.ac.uk/supported/8.3/win32/glib-2.49.4-socket.patch" strip="1"/>
     </branch>
     <dependencies>
       <dep package="libffi"/>
@@ -614,8 +613,8 @@
   <autotools id="cairo" autogenargs="--disable-gl --disable-xlib --disable-xcb --enable-win32 --without-x --disable-svg --disable-ps --disable-script">
     <branch 
       repo="cairo" 
-      module="cairo-1.14.6.tar.xz"
-      version="1.14.6"
+      module="cairo-1.14.8.tar.xz"
+      version="1.14.8"
       >
     </branch>
     <dependencies>
@@ -628,8 +627,8 @@
   <autotools id="pango" autogenargs="--with-cairo --disable-introspection">
     <branch
       repo="gnome"
-      module="pango/1.40/pango-1.40.3.tar.xz"
-      version="1.40.3"
+      module="pango/1.40/pango-1.40.4.tar.xz"
+      version="1.40.4"
       >
     </branch>
     <dependencies>
@@ -668,8 +667,8 @@
     >
     <branch
       repo="gnome"
-      module="libgsf/1.14/libgsf-1.14.40.tar.xz"
-      version="1.14.40">
+      module="libgsf/1.14/libgsf-1.14.41.tar.xz"
+      version="1.14.41">
     </branch>
     <dependencies>
       <dep package="glib"/>

--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,9 @@ if ! type docker > /dev/null; then
   exit 1
 fi
 
+# Ensure latest Ubuntu LTS base image
+docker pull ubuntu:xenial
+
 # Create a machine image with all the required build tools pre-installed
 docker build -t libvips-build-win64 container
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:wily
+FROM ubuntu:xenial
 MAINTAINER Lovell Fuller <npm@lovell.info>
 
 # Install dependencies ... these come in two parts: the first set are for the
@@ -9,6 +9,7 @@ RUN dpkg --add-architecture i386 && \
   apt-get install -y \
     build-essential \
     libxml2-dev \
+    libexpat1-dev \
     glib2.0-dev \
     gobject-introspection \
     python-gi-dev \


### PR DESCRIPTION
A few version bumps, the most important of which is libtiff with some security-related updates, e.g. CVE-2016-9297.

I've also upgraded the container to the LTS version of Ubuntu so it gets the latest tooling when run.

The sharp test suite passes on Windows using the output of these updates - see https://ci.appveyor.com/project/lovell/sharp/build/768/job/nxlpyurapr1tu011