### PR TITLE
 Dependency version bumps for 8.7 release line

### DIFF
--- a/8.7/package-vipsdev.sh
+++ b/8.7/package-vipsdev.sh
@@ -29,11 +29,8 @@ echo cleaning build $repackagedir
 ( cd $repackagedir ; rm -rf _jhbuild )
 
 for i in COPYING ChangeLog README.md AUTHORS; do 
-  ( cp $basedir/$checkoutdir/vips-$vips_version.$vips_minor_version/$i $repackagedir )
+  ( cp $basedir/$checkoutdir/$vips_version.$vips_minor_version/$i $repackagedir )
 done
-
-# rename all the $mingw_prefix-animate etc. without the prefix
-( cd $repackagedir/bin ; for i in $mingw_prefix*; do mv $i `echo $i | sed s/$mingw_prefix//`; done )
 
 # clean /bin 
 ( cd $repackagedir/bin ; mkdir ../poop ; mv *vips* ../poop ; mv *.dll ../poop ; rm -f * ; mv ../poop/* . ; rmdir ../poop )

--- a/8.7/vips.modules
+++ b/8.7/vips.modules
@@ -78,7 +78,7 @@
   <repository 
     type="tarball" 
     name="cairo" 
-    href="http://www.cairographics.org/releases/"
+    href="http://www.cairographics.org/snapshots/"
     />
 
   <repository 
@@ -257,8 +257,8 @@
     >
     <branch
       repo="sourceforge"
-      module="expat/expat-2.2.5.tar.bz2"
-      version="2.2.5"
+      module="expat/expat-2.2.6.tar.bz2"
+      version="2.2.6"
     />
     <dependencies>
       <dep package="zlib"/>
@@ -272,8 +272,8 @@
     >
     <branch 
       repo="nongnu"
-      module="freetype/freetype-2.9.tar.gz"
-      version="2.9"
+      module="freetype/freetype-2.9.1.tar.gz"
+      version="2.9.1"
     />
     <dependencies>
       <dep package="gettext"/>
@@ -291,8 +291,8 @@
     >
     <branch 
       repo="freedesktop.org"
-      module="harfbuzz/release/harfbuzz-1.7.6.tar.bz2"
-      version="1.7.6"
+      module="harfbuzz/release/harfbuzz-1.8.7.tar.bz2"
+      version="1.8.7"
     />
     <dependencies>
       <dep package="gettext"/>
@@ -720,8 +720,8 @@
     >
     <branch
       repo="webp"
-      module="libwebp-0.6.1.tar.gz"
-      version="0.6.1"
+      module="libwebp-1.0.0.tar.gz"
+      version="1.0.0"
       >
     </branch>
     <dependencies>
@@ -758,8 +758,8 @@
     >
     <branch
       repo="gnome"
-      module="glib/2.54/glib-2.54.2.tar.xz"
-      version="2.54.2"
+      module="glib/2.54/glib-2.54.3.tar.xz"
+      version="2.54.3"
       >
     </branch>
     <dependencies>
@@ -797,8 +797,8 @@
     >
     <branch 
       repo="cairo" 
-      module="cairo-1.14.12.tar.xz"
-      version="1.14.12"
+      module="cairo-1.15.12.tar.xz"
+      version="1.15.12"
       >
     </branch>
     <dependencies>
@@ -972,7 +972,7 @@
 
     <branch
       repo="vips"
-      module="v8.7.0-rc1/vips-8.7.0.tar.gz"
+      module="v8.7.0-rc2/vips-8.7.0.tar.gz"
       version="8.7.0"
       >
     </branch>
@@ -1016,7 +1016,7 @@
 
     <branch
       repo="vips"
-      module="v8.7.0-rc1/vips-8.7.0.tar.gz"
+      module="v8.7.0-rc2/vips-8.7.0.tar.gz"
       version="8.7.0"
       checkoutdir="8.7.0"
       >
@@ -1028,13 +1028,13 @@
       <dep package="giflib"/>
       <dep package="glib"/>
       <dep package="pango"/>
-      <dep package="fftw3"/>
       <dep package="libgsf"/>
       <dep package="libjpeg-turbo"/>
       <dep package="tiff"/>
       <dep package="lcms"/>
       <dep package="libexif"/>
       <dep package="libpng"/>
+      <dep package="orc-0.4"/>
     </dependencies>
   </autotools>
 
@@ -1050,7 +1050,7 @@
 
     <branch
       repo="vips"
-      module="v8.7.0-rc1/vips-8.7.0.tar.gz"
+      module="v8.7.0-rc2/vips-8.7.0.tar.gz"
       version="8.7.0"
       checkoutdir="8.7.0"
       >


### PR DESCRIPTION
Hi John, this PR removes the GPL-licenced fftw3 from the web target as sharp doesn't use it, and it keeps the web target at the LGPL level.

I've added orc as a dependency of the web target as my testing suggests the latest version is now stable on Windows.

It also removes an unnecessary rename step that was failing with the new Bionic-based container.

This has all been tested using the sharp test suite on a Windows machine.