### PR TITLE
Prefer native win32 threading functionality

### DIFF
--- a/8.8/Toolchain-x86_64-w64-mingw32.cmake
+++ b/8.8/Toolchain-x86_64-w64-mingw32.cmake
@@ -12,9 +12,13 @@ set(BUILD_STATIC OFF CACHE BOOL "BUILD_STATIC")
 set(LIBTYPE SHARED)
 
 ## programs
-SET(CMAKE_C_COMPILER x86_64-w64-mingw32-gcc)
-SET(CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++)
-SET(CMAKE_RC_COMPILER x86_64-w64-mingw32-windres)
+set(CMAKE_C_COMPILER x86_64-w64-mingw32-gcc)
+
+if(NOT CMAKE_CXX_COMPILER)
+  set(CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++)
+endif()
+
+set(CMAKE_RC_COMPILER x86_64-w64-mingw32-windres)
 # Don't set the following variables in our toolchain,
 # because it will break the cfitsio/harfbuzz build, see:
 # https://cmake.org/pipermail/cmake/2010-March/035540.html
@@ -22,7 +26,7 @@ SET(CMAKE_RC_COMPILER x86_64-w64-mingw32-windres)
 # SET(CMAKE_RANLIB x86_64-w64-mingw32-ranlib)
 
 # target environment location
-SET(CMAKE_FIND_ROOT_PATH /data/inst CACHE PATH "List of root paths to search on the filesystem")
+set(CMAKE_FIND_ROOT_PATH /data/inst CACHE PATH "List of root paths to search on the filesystem")
 set(CMAKE_PREFIX_PATH /data/inst CACHE PATH "List of directories specifying installation prefixes to be searched")
 set(CMAKE_INSTALL_PREFIX /data/inst CACHE PATH "Installation Prefix")
 

--- a/8.8/package-vipsdev.sh
+++ b/8.8/package-vipsdev.sh
@@ -26,7 +26,7 @@ echo "Copying libvips and dependencies"
   $installdir/bin/libvips-cpp-42.dll \
   --clear-path \
   --path $installdir/bin \
-  --path /usr/lib/gcc/x86_64-w64-mingw32/*-posix \
+  --path /usr/lib/gcc/x86_64-w64-mingw32/*-win32 \
   --path /usr/x86_64-w64-mingw32/lib/ \
   -a \
   -w USERENV.dll \

--- a/8.8/vips.modules
+++ b/8.8/vips.modules
@@ -402,8 +402,12 @@
     </dependencies>
   </autotools>
 
+  <!-- Build with g++-posix because Poppler needs std::recursive_mutex
+
+    -->
+
   <cmake id="poppler"
-    cmakeargs="-DENABLE_ZLIB=ON -DENABLE_LIBTIFF=ON -DENABLE_LIBPNG=ON -DENABLE_GLIB=ON -DENABLE_CMS='lcms2' -DENABLE_LIBOPENJPEG='openjpeg2' -DENABLE_DCTDECODER='libjpeg' -DFONT_CONFIGURATION=win32 -DENABLE_SPLASH=OFF -DENABLE_CPP=OFF"
+    cmakeargs="-DCMAKE_CXX_COMPILER=/usr/bin/x86_64-w64-mingw32-g++-posix -DENABLE_ZLIB=ON -DENABLE_LIBTIFF=ON -DENABLE_LIBPNG=ON -DENABLE_GLIB=ON -DENABLE_CMS='lcms2' -DENABLE_LIBOPENJPEG='openjpeg2' -DENABLE_DCTDECODER='libjpeg' -DFONT_CONFIGURATION=win32 -DENABLE_SPLASH=OFF -DENABLE_CPP=OFF"
     use-ninja="False">
     <pkg-config>poppler-glib.pc</pkg-config>
     <branch
@@ -658,7 +662,7 @@
     -->
 
   <meson id="glib"
-    mesonargs="-Dforce_posix_threads=true -Dinternal_pcre=true -Diconv='external'">
+    mesonargs="-Dforce_posix_threads=false -Dinternal_pcre=true -Diconv='external'">
     <branch
       repo="gnome"
       module="glib/2.61/glib-2.61.0.tar.xz"

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -10,27 +10,22 @@ RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula selec
   && apt-get install -y \
     build-essential \
     git \
+    zip \
     libtool \
     intltool \
     mingw-w64 \
     mingw-w64-tools \
     nasm \
     cmake \
-    # needed for JHBuild
+    # needed by fontconfig
+    gperf \
+    # needed by JHBuild
     python-minimal \
     # needed for Ninja and Meson
     python3-pip \
-    # needed for pe-util
+    # needed by pe-util
     libboost-filesystem-dev \
     libboost-system-dev
-
-# we need to set the the default mingw32 g++ and gcc compiler option to 
-# posix, since poppler, openjpeg and libheif needs to be compiled with posix 
-# thread support
-RUN update-alternatives --set x86_64-w64-mingw32-gcc \
-    /usr/bin/x86_64-w64-mingw32-gcc-posix \
-  && update-alternatives --set x86_64-w64-mingw32-g++ \
-    /usr/bin/x86_64-w64-mingw32-g++-posix
 
 # build source packages here
 WORKDIR /usr/local/src
@@ -42,20 +37,6 @@ RUN git clone https://github.com/GNOME/jhbuild.git \
    && ./autogen.sh --prefix=/usr/local \
    && make \
    && make install
-
-# without this, configuring tzdata will ask for a time zone
-# croco needs gtk-doc
-RUN export DEBIAN_FRONTEND=noninteractive \
-  && export DEBCONF_NONINTERACTIVE_SEEN=true \
-  && echo "tzdata tzdata/Areas select Europe" > /tmp/preseed.txt \
-  && echo "tzdata tzdata/Zones/Europe select London" >> /tmp/preseed.txt \
-  && debconf-set-selections /tmp/preseed.txt \
-  && apt-get install -y \
-    gtk-doc-tools \
-    xmlto \
-    wget \
-    yelp-tools \
-    gperf
 
 # install Ninja and Meson
 RUN pip3 install ninja meson


### PR DESCRIPTION
This PR disables the POSIX threads switch which was introduced in https://github.com/libvips/build-win64/pull/26. While I was debugging the slowdown on Windows for [this PR](https://github.com/bleroy/core-imaging-playground/pull/15), I noticed that the POSIX threads functionality is slower than the native Win32 implementation.

For example, I see a ±8 ms improvement on the [core-imaging-playground](https://devblogs.microsoft.com/dotnet/net-core-image-processing/)  benchmark:

<details><summary>Benchmark results before this PR</summary>

``` ini

BenchmarkDotNet=v0.11.5, OS=Windows 10.0.17763.503 (1809/October2018Update/Redstone5)
Intel Core i5-8600K CPU 3.60GHz (Coffee Lake), 1 CPU, 6 logical and 6 physical cores
.NET Core SDK=2.2.204
  [Host]            : .NET Core 2.2.5 (CoreCLR 4.6.27617.05, CoreFX 4.6.27618.01), 64bit RyuJIT
  .Net Core 2.2 CLI : .NET Core 2.2.5 (CoreCLR 4.6.27617.05, CoreFX 4.6.27618.01), 64bit RyuJIT

Job=.Net Core 2.2 CLI  Toolchain=.NET Core 2.2  IterationCount=5  
LaunchCount=1  WarmupCount=5  

```
|                       Method |     Mean |    Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------- |---------:|---------:|----------:|------:|------:|------:|----------:|
| &#39;NetVips Load, Resize, Save&#39; | 145.9 ms | 1.894 ms | 0.4918 ms |     - |     - |     - | 122.05 KB |

</details>


<details><summary>Benchmark results after this PR</summary>

``` ini

BenchmarkDotNet=v0.11.5, OS=Windows 10.0.17763.503 (1809/October2018Update/Redstone5)
Intel Core i5-8600K CPU 3.60GHz (Coffee Lake), 1 CPU, 6 logical and 6 physical cores
.NET Core SDK=2.2.204
  [Host]            : .NET Core 2.2.5 (CoreCLR 4.6.27617.05, CoreFX 4.6.27618.01), 64bit RyuJIT
  .Net Core 2.2 CLI : .NET Core 2.2.5 (CoreCLR 4.6.27617.05, CoreFX 4.6.27618.01), 64bit RyuJIT

Job=.Net Core 2.2 CLI  Toolchain=.NET Core 2.2  IterationCount=5  
LaunchCount=1  WarmupCount=5  

```
|                       Method |     Mean |    Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------- |---------:|---------:|----------:|------:|------:|------:|----------:|
| &#39;NetVips Load, Resize, Save&#39; | 137.9 ms | 3.745 ms | 0.9726 ms |     - |     - |     - | 122.05 KB |

</details>

This benchmark will thumbnail 12 images to 150x150 pixels. Because this operation can be done quite quickly, a large threadpool could slow down processing overall (thanks John for the notice). 

With `VIPS_CONCURRENCY` set to 1, I see:
<details><summary>Benchmark results with VIPS_CONCURRENCY=1</summary>

``` ini

BenchmarkDotNet=v0.11.5, OS=Windows 10.0.17763.503 (1809/October2018Update/Redstone5)
Intel Core i5-8600K CPU 3.60GHz (Coffee Lake), 1 CPU, 6 logical and 6 physical cores
.NET Core SDK=2.2.204
  [Host]            : .NET Core 2.2.5 (CoreCLR 4.6.27617.05, CoreFX 4.6.27618.01), 64bit RyuJIT
  .Net Core 2.2 CLI : .NET Core 2.2.5 (CoreCLR 4.6.27617.05, CoreFX 4.6.27618.01), 64bit RyuJIT

Job=.Net Core 2.2 CLI  Toolchain=.NET Core 2.2  IterationCount=5  
LaunchCount=1  WarmupCount=5  

```
|                       Method |     Mean |    Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------- |---------:|---------:|----------:|------:|------:|------:|----------:|
| &#39;NetVips Load, Resize, Save&#39; | 129.8 ms | 2.296 ms | 0.5962 ms |     - |     - |     - | 122.05 KB |

</details>

The `x86_64-w64-mingw32-g++-posix` compiler will only be used to build Poppler which needs `std::recursive_mutex`. I thought that OpenJPEG and libheif also needed the `-posix` compiler but they seem to build with the regular MinGW-w64 compiler.

This PR also fixes the broken `--vips-profile`  option caused by the switch to POSIX threads. Before this PR I saw this:
```bash
C:\vips-dev-8.8\bin> vipsthumbnail.exe DSCN0533.jpg -s 150x150 -o output.jpg[strip,Q=75] --vips-profile
recording profile in vips-profile.txt
Exception code=0xc0000005 flags=0x0 at 0x000000005EDD529B. Access violation - attempting to read data at address 0x0000000000000008
```

Perhaps that will need some further debugging, it shouldn't throw exceptions for any kind of threading functionality.