### PR TITLE
Ensure gdk-pixbuf can find libjpeg-turbo when cross-compiling

### DIFF
--- a/8.8/patches/gdk-pixbuf-libjpeg-turbo.patch
+++ b/8.8/patches/gdk-pixbuf-libjpeg-turbo.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index 6c5fa36cb..0609846f1 100644
+--- a/meson.build
++++ b/meson.build
+@@ -308,7 +308,7 @@ endif
+ # Don't check and build the jpeg loader if native_windows_loaders is true
+ if get_option('jpeg') and not native_windows_loaders
+   if cc.has_header('jpeglib.h')
+-    jpeg_dep = cc.find_library('jpeg', required: false)
++    jpeg_dep = dependency('libjpeg', required: false)
+     if cc.get_id() == 'msvc' and not jpeg_dep.found()
+       # The IJG JPEG library builds the .lib file as libjpeg.lib in its MSVC build system,
+       # so look for it as well when jpeg.lib cannot be found

--- a/8.8/vips.modules
+++ b/8.8/vips.modules
@@ -737,7 +737,9 @@
     <branch
       repo="gnome"
       module="gdk-pixbuf/2.38/gdk-pixbuf-2.38.1.tar.xz"
-      version="2.38.1"/>
+      version="2.38.1">
+      <patch file="patches/gdk-pixbuf-libjpeg-turbo.patch" strip="1"/>
+    </branch>
     <dependencies>
       <dep package="glib"/>
       <dep package="libjpeg-turbo"/>
@@ -875,7 +877,7 @@
 
     <branch
       repo="vips"
-      module="v8.8.0-rc3/vips-8.8.0-rc3.tar.gz"
+      module="v8.8.0/vips-8.8.0.tar.gz"
       version="8.8.0"
       checkoutdir="vips-8.8.0"/>
 
@@ -926,7 +928,7 @@
 
     <branch
       repo="vips"
-      module="v8.8.0-rc3/vips-8.8.0-rc3.tar.gz"
+      module="v8.8.0/vips-8.8.0.tar.gz"
       version="8.8.0"
       checkoutdir="vips-8.8.0"/>
 
@@ -957,7 +959,7 @@
 
     <branch
       repo="vips"
-      module="v8.8.0-rc3/vips-8.8.0-rc3.tar.gz"
+      module="v8.8.0/vips-8.8.0.tar.gz"
       version="8.8.0"
       checkoutdir="vips-8.8.0">
       <patch file="patches/transform.patch" strip="1"/>


### PR DESCRIPTION
One of the sharp unit tests was failing to render an embedded JPEG within an SVG on Windows with the latest 8.8.0 release. This was due to gdk-pixbuf being unable to find libjpeg-turbo at compile time.

With the change in this PR, to use the libjpeg 8 ABI and search for it via pkg-config, the binaries it provides now allows all the sharp tests to pass.

(I guess we could also submit a variant of this patch upstream to the gdk-pixbuf project to use meson's `dependency` as a fallback for `find_library`.)

This PR also bumps vips from a release candidate to the supported v8.8.0.