### PR TITLE
Dependency version bumps for 8.8

### DIFF
--- a/8.8/patches/openslide-3-fixes.patch
+++ b/8.8/patches/openslide-3-fixes.patch
@@ -1,7 +1,168 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Benjamin Gilbert <bgilbert@cs.cmu.edu>
+Date: Mon, 7 Sep 2015 22:28:22 -0400
+Subject: [PATCH 1/3] On Windows, assume filenames are in UTF-8, not the system
+ codepage
+
+On Windows, fopen() expects filenames in the system codepage, and thus
+can't handle arbitrary characters.  Assume filenames are in UTF-8,
+convert to UTF-16, and pass to _wfopen().
+
+http://lists.andrew.cmu.edu/pipermail/openslide-users/2015-September/001098.html
+
+diff --git a/configure.ac b/configure.ac
+index 1111111..2222222 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -180,6 +180,9 @@ AS_CASE([$host_os],
+ # Fallback: racily use fcntl()
+ AC_CHECK_FUNCS([fcntl])
+ 
++# Windows _wfopen()
++AC_CHECK_FUNCS([_wfopen])
++
+ # The test driver has special support for testing Windows builds from Cygwin
+ AC_MSG_CHECKING([whether to cross-test from Cygwin])
+ if test "$host_os" = "mingw32" -a "$build_os" = "cygwin"; then
+diff --git a/src/openslide-util.c b/src/openslide-util.c
+index 1111111..2222222 100644
+--- a/src/openslide-util.c
++++ b/src/openslide-util.c
+@@ -2,6 +2,7 @@
+  *  OpenSlide, a library for reading whole slide image files
+  *
+  *  Copyright (c) 2007-2015 Carnegie Mellon University
++ *  Copyright (c) 2015 Benjamin Gilbert
+  *  All rights reserved.
+  *
+  *  OpenSlide is free software: you can redistribute it and/or modify
+@@ -157,14 +158,46 @@ FAIL:
+ }
+ 
+ #undef fopen
++static FILE *do_fopen(const char *path, const char *mode, GError **err) {
++  FILE *f;
++
++#ifdef HAVE__WFOPEN
++  wchar_t *path16 = (wchar_t *) g_convert(path, -1, "UTF-16", "UTF-8",
++                                          NULL, NULL, err);
++  if (path16 == NULL) {
++    g_prefix_error(err, "Couldn't open %s: ", path);
++    return NULL;
++  }
++  wchar_t *mode16 = (wchar_t *) g_convert(mode, -1, "UTF-16", "UTF-8",
++                                          NULL, NULL, err);
++  if (mode16 == NULL) {
++    g_prefix_error(err, "Bad file mode %s: ", mode);
++    g_free(path16);
++    return NULL;
++  }
++  f = _wfopen(path16, mode16);
++  if (f == NULL) {
++    _openslide_io_error(err, "Couldn't open %s", path);
++  }
++  g_free(mode16);
++  g_free(path16);
++#else
++  f = fopen(path, mode);
++  if (f == NULL) {
++    _openslide_io_error(err, "Couldn't open %s", path);
++  }
++#endif
++
++  return f;
++}
++#define fopen _OPENSLIDE_POISON(_openslide_fopen)
++
+ FILE *_openslide_fopen(const char *path, const char *mode, GError **err)
+ {
+   char *m = g_strconcat(mode, FOPEN_CLOEXEC_FLAG, NULL);
+-  FILE *f = fopen(path, m);
++  FILE *f = do_fopen(path, m, err);
+   g_free(m);
+-
+   if (f == NULL) {
+-    _openslide_io_error(err, "Couldn't open %s", path);
+     return NULL;
+   }
+ 
+@@ -193,7 +226,6 @@ FILE *_openslide_fopen(const char *path, const char *mode, GError **err)
+ 
+   return f;
+ }
+-#define fopen _OPENSLIDE_POISON(_openslide_fopen)
+ 
+ #undef g_ascii_strtod
+ double _openslide_parse_double(const char *value) {
+diff --git a/src/openslide.h b/src/openslide.h
+index 1111111..2222222 100644
+--- a/src/openslide.h
++++ b/src/openslide.h
+@@ -62,7 +62,7 @@ typedef struct _openslide openslide_t;
+  * Otherwise, return NULL.  Calling openslide_open() on this file will also
+  * return NULL.
+  *
+- * @param filename The filename to check.
++ * @param filename The filename to check.  On Windows, this must be in UTF-8.
+  * @return An identification of the format vendor for this file, or NULL.
+  * @since 3.4.0
+  */
+@@ -78,7 +78,7 @@ const char *openslide_detect_vendor(const char *filename);
+  * request.  Instead, it should maintain a cache of OpenSlide objects and
+  * reuse them when possible.
+  *
+- * @param filename The filename to open.
++ * @param filename The filename to open.  On Windows, this must be in UTF-8.
+  * @return
+  *         On success, a new OpenSlide object.
+  *         If the file is not recognized by OpenSlide, NULL.
+@@ -463,7 +463,7 @@ const char *openslide_get_version(void);
+  * openslide_open(), but it could also erroneously return @p true in some
+  * cases where openslide_open() would fail.
+  *
+- * @param filename The filename to check.
++ * @param filename The filename to check.  On Windows, this must be in UTF-8.
+  * @return If openslide_open() will succeed.
+  * @deprecated Use openslide_detect_vendor() to efficiently check whether
+  *             a slide file is recognized by OpenSlide, or just call
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Benjamin Gilbert <bgilbert@cs.cmu.edu>
+Date: Sun, 15 May 2016 23:37:33 -0500
+Subject: [PATCH 2/3] Use g_utf8_to_utf16() to compute Windows file paths
+
+On glib 2.47.6 through at least 2.48.1, g_convert() adds a BOM to the
+beginning of the returned string, causing _wfopen() to fail.  Switch to
+g_utf8_to_utf16(), which should also be more efficient.
+
+Fixes #176.
+
+diff --git a/src/openslide-util.c b/src/openslide-util.c
+index 1111111..2222222 100644
+--- a/src/openslide-util.c
++++ b/src/openslide-util.c
+@@ -162,14 +162,12 @@ static FILE *do_fopen(const char *path, const char *mode, GError **err) {
+   FILE *f;
+ 
+ #ifdef HAVE__WFOPEN
+-  wchar_t *path16 = (wchar_t *) g_convert(path, -1, "UTF-16", "UTF-8",
+-                                          NULL, NULL, err);
++  wchar_t *path16 = (wchar_t *) g_utf8_to_utf16(path, -1, NULL, NULL, err);
+   if (path16 == NULL) {
+     g_prefix_error(err, "Couldn't open %s: ", path);
+     return NULL;
+   }
+-  wchar_t *mode16 = (wchar_t *) g_convert(mode, -1, "UTF-16", "UTF-8",
+-                                          NULL, NULL, err);
++  wchar_t *mode16 = (wchar_t *) g_utf8_to_utf16(mode, -1, NULL, NULL, err);
+   if (mode16 == NULL) {
+     g_prefix_error(err, "Bad file mode %s: ", mode);
+     g_free(path16);
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kleis Auke Wolthuizen <github@kleisauke.nl>
 Date: Sat, 2 June 2018 14:20:00 +0200
-Subject: [PATCH 1/1] Windows fixes
+Subject: [PATCH 3/3] Windows fixes
 
 - Fix compile errors with labeled statements named `OUT`.
 - The `host_os` and `build_os` variables may contain the
@@ -32,7 +193,7 @@ index 1111111..2222222 100644
      # Assume that if we're building for Windows, we want to pass N to fopen().
      AC_MSG_RESULT([N])
      AC_DEFINE([FOPEN_CLOEXEC_FLAG], ["N"], [Set to the fopen() flag string that sets FD_CLOEXEC, or an empty string if not supported.])
-@@ -182,28 +185,39 @@ AC_CHECK_FUNCS([fcntl])
+@@ -185,28 +188,39 @@ AC_CHECK_FUNCS([_wfopen])
  
  # The test driver has special support for testing Windows builds from Cygwin
  AC_MSG_CHECKING([whether to cross-test from Cygwin])
@@ -63,7 +224,7 @@ index 1111111..2222222 100644
 -else
 -  CFLAG_MS_FORMAT=""
 -fi
-+# The CFLAG_NO_PSEUDO_MODIFIERS variable prevents Windows.h from 
++# The CFLAG_NO_PSEUDO_MODIFIERS variable prevents Windows.h from
 +# defining IN or OUT.
 +case "$host_os" in
 +  mingw32*)

--- a/8.8/vips.modules
+++ b/8.8/vips.modules
@@ -3,64 +3,15 @@
 <?xml-stylesheet type="text/xsl" href="moduleset.xsl"?>
 <moduleset>
 
-  <!-- git repos -->
-  <repository type="git" name="git.gnome.org" default="yes"
-    href="git://git.gnome.org/"/>
-  <repository type="git" name="git.freedesktop.org"
-    href="git://anongit.freedesktop.org/"/>
-  <repository type="git" name="gstreamer.freedesktop.org"
-    href="git://anongit.freedesktop.org/gstreamer/"/>
-  <repository type="git" name="telepathy.freedesktop.org"
-    href="git://anongit.freedesktop.org/telepathy/"/>
-  <repository type="git" name="wayland.freedesktop.org"
-    href="git://anongit.freedesktop.org/git/wayland"/>
-  <repository type="git" name="xorg.freedesktop.org"
-    href="git://anongit.freedesktop.org/git/xorg"/>
-  <repository type="git" name="github.com"
-    href="git://github.com/"/>
-  <repository type="bzr" name="research.operationaldynamics.com"
-    href="http://research.operationaldynamics.com/bzr"/>
-  <repository type="git" name="linuxwacom.git.sourceforge.net"
-    href="git://linuxwacom.git.sourceforge.net/"/>
-  <repository type="git" name="quvi"
-    href="git://repo.or.cz/"/>
-
   <!-- tarball repos -->
-  <repository type="tarball" name="cairo.org"
-    href="http://cairographics.org/"/>
-  <repository type="tarball" name="iso-codes"
-    href="http://pkg-isocodes.alioth.debian.org/downloads/"/>
-  <repository type="tarball" name="sourceforge.net"
-    href="http://sourceforge.net/projects/"/>
-  <repository type="tarball" name="webkitgtk.org"
-    href="http://webkitgtk.org/releases/"/>
-  <repository type="tarball" name="freedesktop.org"
+  <repository 
+    type="tarball" 
+    name="freedesktop.org"
     href="http://freedesktop.org/software/"/>
-  <repository type="tarball" name="people.freedesktop.org"
-    href="http://people.freedesktop.org/"/>
-  <repository type="tarball" name="icon-theme.freedesktop.org"
-    href="http://icon-theme.freedesktop.org/releases/"/>
-  <repository type="tarball" name="nice.freedesktop.org"
-    href="http://nice.freedesktop.org/releases/"/>
-  <repository type="tarball" name="libpwquality"
-    href="https://fedorahosted.org/releases/l/i/libpwquality/"/>
-  <repository type="tarball" name="ftp.mozilla.org"
-    href="http://ftp.mozilla.org/"/>
-  <repository type="tarball" name="kernel.org"
-    href="http://www.kernel.org"/>
-  <repository type="tarball" name="ftp.gnu.org"
-    href="http://ftp.gnu.org/gnu/"/>
-  <repository type="tarball" name="libndp"
-    href="http://libndp.org/files/"/>
-  <repository type="tarball" name="mir"
-    href="https://launchpad.net/mir/"/>
-  <repository type="tarball" name="xorg-tar"
-    href="http://xorg.freedesktop.org/"/>
-  <repository type="tarball" name="github-tar"
-    href="https://github.com/"/>
-  <repository type="tarball" name="libxkbcommon"
-    href="http://xkbcommon.org/download/"/>
-  <repository type="tarball" name="poppler.freedesktop.org"
+
+  <repository
+    type="tarball" 
+    name="poppler.freedesktop.org"
     href="http://poppler.freedesktop.org/"/>
 
   <repository
@@ -120,23 +71,8 @@
 
   <repository
     type="tarball"
-    name="cam"
-    href="ftp://ftp.csx.cam.ac.uk/pub/software/programming/"/>
-
-  <repository
-    type="tarball"
-    name="graphviz"
-    href="http://www.graphviz.org/pub/graphviz/stable/SOURCES/"/>
-
-  <repository
-    type="tarball"
     name="cfitsio"
     href="http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/"/>
-
-  <repository
-    type="tarball"
-    name="fcgi"
-    href="http://www.fastcgi.com/dist/"/>
 
   <repository
     type="tarball"
@@ -162,16 +98,6 @@
     type="tarball"
     name="magick"
     href="https://github.com/ImageMagick/ImageMagick6/archive/"/>
-
-  <repository
-    type="tarball"
-    name="jpeg"
-    href="http://www.ijg.org/files/"/>
-
-  <repository
-    type="tarball"
-    name="github"
-    href="http://github.com/"/>
 
   <repository
     type="tarball"
@@ -251,8 +177,8 @@
     autogen-sh="configure">
     <branch
       repo="sourceforge"
-      module="expat/expat-2.2.6.tar.bz2"
-      version="2.2.6"/>
+      module="expat/expat-2.2.7.tar.bz2"
+      version="2.2.7"/>
     <dependencies>
       <dep package="zlib"/>
       <dep package="gettext"/>
@@ -412,8 +338,8 @@
     <pkg-config>poppler-glib.pc</pkg-config>
     <branch
       repo="poppler.freedesktop.org"
-      module="poppler-0.76.1.tar.xz"
-      version="0.76.1"/>
+      module="poppler-0.79.0.tar.xz"
+      version="0.79.0"/>
     <dependencies>
       <dep package="zlib"/>
       <dep package="cairo"/>
@@ -487,7 +413,8 @@
     </dependencies>
   </autotools>
 
-  <!-- the openslide-3-fixes.patch fixes compile errors
+  <!-- the openslide-3-fixes.patch handles UTF-8 
+       filenames correctly and fixes compile errors
        with labeled statements named `OUT`.
 
        switch `autogen-sh="autoreconf"` to `autogen-sh="configure"`
@@ -591,9 +518,9 @@
     autogenargs="--without-x --without-lzma --without-modules --without-openexr --without-heic --without-gvc --without-lqr --without-magick-plus-plus --disable-largefile --without-rsvg --without-zlib --disable-openmp">
     <branch
       repo="magick"
-      module="6.9.10-43.tar.gz"
-      version="6.9.10-43"
-      checkoutdir="ImageMagick6-6.9.10-43"/>
+      module="6.9.10-58.tar.gz"
+      version="6.9.10-58"
+      checkoutdir="ImageMagick6-6.9.10-58"/>
     <dependencies>
       <dep package="lcms"/>
       <dep package="fftw3"/>
@@ -816,8 +743,8 @@
     autogenargs="--disable-static ac_cv_va_copy=C99">
     <branch
       repo="sourceforge"
-      module="matio/matio-1.5.15.tar.gz"
-      version="1.5.15"/>
+      module="matio/matio-1.5.17.tar.gz"
+      version="1.5.17"/>
     <dependencies>
       <dep package="gettext"/>
       <dep package="zlib"/>


### PR DESCRIPTION
A few security-related version bumps (CVE-2018-20843, CVE-2019-13107) and general clean-ups. All tested successfully with the libvips test-suite.

I've included commit openslide/openslide@89bba00 and openslide/openslide@bbc8ae2 within the OpenSlide patches to aid https://github.com/kleisauke/net-vips/issues/43. This can be reproduced on Windows with:
```bash
vips openslideload CMU-1_001┤·©ı.svs x.jpg
```