### PR TITLE
Fix build failures with Rust v1.45.0

### DIFF
--- a/8.10/jhbuildrc
+++ b/8.10/jhbuildrc
@@ -91,7 +91,12 @@ os.environ['CXXFLAGS'] += ' -O3'
 #os.environ['CXXFLAGS'] += ' -g'
 
 # special flags for Rust
-os.environ['RUSTFLAGS'] = '-Copt-level=s -Clto=on -Ccodegen-units=1 -Cincremental=false -Cpanic=abort'
+os.environ['CARGO_PROFILE_RELEASE_DEBUG'] = 'false'
+os.environ['CARGO_PROFILE_RELEASE_CODEGEN_UNITS'] = '1'
+os.environ['CARGO_PROFILE_RELEASE_INCREMENTAL'] = 'false'
+os.environ['CARGO_PROFILE_RELEASE_LTO'] = 'true'
+os.environ['CARGO_PROFILE_RELEASE_OPT_LEVEL'] = 's'
+os.environ['CARGO_PROFILE_RELEASE_PANIC'] = 'abort'
 
 # do not interact with the user
 interact = False

--- a/8.10/patches/libspng-0.6-fixes.patch
+++ b/8.10/patches/libspng-0.6-fixes.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Randy <randy408@protonmail.com>
+Date: Wed, 29 Jul 2020 15:31:50 +0200
+Subject: [PATCH 1/1] Ignore spec violation for tRNS chunks (fixes #118)
+
+
+diff --git a/spng/spng.c b/spng/spng.c
+index 1111111..2222222 100644
+--- a/spng/spng.c
++++ b/spng/spng.c
+@@ -208,6 +208,7 @@ struct spng_ctx
+     unsigned streaming: 1;
+ 
+     unsigned encode_only: 1;
++    unsigned strict : 1;
+ 
+     /* input file contains this chunk */
+     struct spng_chunk_bitfield file;
+@@ -1884,7 +1885,14 @@ static int read_non_idat_chunks(spng_ctx *ctx)
+                 }
+                 ctx->trns.n_type3_entries = chunk.length;
+             }
+-            else return SPNG_ETRNS_COLOR_TYPE;
++
++            /* The standard explicitly forbids tRNS chunks for grayscale alpha,
++                truecolor alpha images but libpng only emits a warning by default. */
++            if(ctx->ihdr.color_type == 4 || ctx->ihdr.color_type == 6)
++            {
++                if(ctx->strict) return SPNG_ETRNS_COLOR_TYPE;
++                else continue;
++            }
+ 
+             ctx->file.trns = 1;
+             ctx->stored.trns = 1;

--- a/8.10/vips.modules
+++ b/8.10/vips.modules
@@ -79,11 +79,10 @@
     name="proxy-libintl"
     href="https://github.com/frida/proxy-libintl/tarball/"/>
 
-  <!-- href="https://github.com/randy408/libspng/archive/" -->
   <repository
     type="tarball"
     name="libspng"
-    href="https://github.com/randy408/libspng/tarball/"/>
+    href="https://github.com/randy408/libspng/archive/"/>
 
   <repository
     type="tarball"
@@ -303,9 +302,11 @@
   <meson id="libspng">
     <branch
       repo="libspng"
-      module="${version}"
+      module="v${version}.tar.gz"
       checkoutdir="libspng-${version}"
-      version="9a08896"/>
+      version="0.6.0">
+      <patch file="patches/libspng-0.6-fixes.patch" strip="1"/>
+    </branch>
     <dependencies>
       <dep package="zlib"/>
     </dependencies>


### PR DESCRIPTION
This is similar to https://github.com/lovell/sharp-libvips/pull/48. I've also backported the libspng patch to fix https://github.com/libvips/libvips/issues/1748.